### PR TITLE
Maven Central Repository

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -13,6 +13,7 @@ grails.project.dependency.resolution = {
 		grailsHome()
 		grailsCentral()
 
+		mavenCentral()
 		mavenRepo 'http://repository.jboss.com/maven2/'
 	}
 


### PR DESCRIPTION
Hi, Burt

I've downloaded the source code of this plugin and, for compiling it, I had to add mavenCentral() to BuildConfig.groovy. It took me some time till I find the solution (I know, I should read the tutorial first of all :P).
Is it possible adding this by default in BuildConfig of this plugin?

Thank you for your attention!
